### PR TITLE
Added support for compilation on glibc 2.33 and onwards

### DIFF
--- a/ldp_fuse/include/ldpfuse.h
+++ b/ldp_fuse/include/ldpfuse.h
@@ -29,7 +29,19 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+
+/*
+  from version GLIBC 2.32 unistd.h contains constant definitions that we need, but also `close_range`
+  This causes conflicts as symbols with those names are also
+  necessarily defined here. We therefore overwrite them using #define.
+*/
+#if (__GLIBC__ > 1 && __GLIBC_MINOR__ > 32)
+#define close_range __renamed_close_range
 #include <unistd.h>
+#undef close_range
+#else 
+#include <unistd.h>
+#endif
 
 // Include `cwalk` directly as this lib is header-only
 #include "./cwalk.c"
@@ -418,7 +430,15 @@ static char* resolve_fd(int fd) {
 
 #define LDP_FUSE_PATH_MAX_LEN 256
 
+/*
+  from version 2.32 glibc does not have the _STAT_VER macro
+  defined in "sys/stat.h"
+*/
+#if (__GLIBC__ > 1 && __GLIBC_MINOR__ > 32)
+#define STAT_VER 0 
+#else
 #define STAT_VER _STAT_VER
+#endif
 
 // Whether `path` is in the LDP_FUSE filesystem. The LDP_FUSE filesystem is
 // mounted under the LDP_FUSE_PATH env variable.


### PR DESCRIPTION
I tried to compile the passthrough example module and encountered the following error:
```
cc -D LDP_FUSE_THREAD_SAFE -Wall -I ../../ldp_fuse/include -fPIC -c passthrough.c
In file included from passthrough.c:2:
../../ldp_fuse/include/ldpfuse.h: In function ‘fstatat_wrapper’:
../../ldp_fuse/include/ldpfuse.h:421:18: error: ‘_STAT_VER’ undeclared (first use in this function); did you mean ‘STAT_VER’?
  421 | #define STAT_VER _STAT_VER
      |                  ^~~~~~~~~
../../ldp_fuse/include/ldpfuse.h:535:27: note: in expansion of macro ‘STAT_VER’
  535 |   int ret = orig_fxstatat(STAT_VER, dirfd, pathname, statbuf, flags);
      |                           ^~~~~~~~
../../ldp_fuse/include/ldpfuse.h:421:18: note: each undeclared identifier is reported only once for each function it appears in
  421 | #define STAT_VER _STAT_VER
      |                  ^~~~~~~~~
../../ldp_fuse/include/ldpfuse.h:535:27: note: in expansion of macro ‘STAT_VER’
  535 |   int ret = orig_fxstatat(STAT_VER, dirfd, pathname, statbuf, flags);
      |                           ^~~~~~~~
../../ldp_fuse/include/ldpfuse.h: In function ‘__fxstatat’:
../../ldp_fuse/include/ldpfuse.h:421:18: error: ‘_STAT_VER’ undeclared (first use in this function); did you mean ‘STAT_VER’?
  421 | #define STAT_VER _STAT_VER
      |                  ^~~~~~~~~
../../ldp_fuse/include/ldpfuse.h:558:26: note: in expansion of macro ‘STAT_VER’
  558 |     return orig_fxstatat(STAT_VER, dirfd, pathname, statbuf, flags);
      |                          ^~~~~~~~
../../ldp_fuse/include/ldpfuse.h: At top level:
../../ldp_fuse/include/ldpfuse.h:889:5: error: conflicting types for ‘close_range’; have ‘int(unsigned int,  unsigned int,  unsigned int)’
  889 | int close_range(unsigned int first, unsigned int last, unsigned int flags) {
      |     ^~~~~~~~~~~
In file included from ../../ldp_fuse/include/ldpfuse.h:32,
                 from passthrough.c:2:
/usr/include/unistd.h:1208:12: note: previous declaration of ‘close_range’ with type ‘int(unsigned int,  unsigned int,  int)’
 1208 | extern int close_range (unsigned int __fd, unsigned int __max_fd,
      |            ^~~~~~~~~~~
In file included from passthrough.c:2:
../../ldp_fuse/include/ldpfuse.h: In function ‘__fxstatat’:
../../ldp_fuse/include/ldpfuse.h:560:1: warning: control reaches end of non-void function [-Wreturn-type]
  560 | }
      | ^
make: *** [Makefile:21: passthrough.o] Error 1
```
ldd --version gives the following version:
```
ldd (Ubuntu GLIBC 2.35-0ubuntu3.5) 2.35
```

Looking at the source code of glibc, It seems to be the case that from version [2.33](https://elixir.bootlin.com/glibc/glibc-2.33/C/ident/_STAT_VER) `_STAT_VER` is not
not defined in `sys/stat.h`.

The only definitions seems to be in these files
![_stat_ver2 33](https://github.com/sholtrop/ldpfuse/assets/23554564/155f7a41-5831-47f3-a832-bce84027e0dd)
Including `xstatver.h` in `ldpfuse.h` does not compile.

I have made the default 0 as this seems to be what the macro expands to after version 2.33. There should be a better alternative but this compiled and worked with the passthrough example.

This also had to be added as there was a conflict with the close_range symbol.
```c
#if (__GLIBC__ > 1 && __GLIBC_MINOR__ > 32)
#define close_range __renamed_close_range
#include <unistd.h>
#undef close_range
#else 
#include <unistd.h>
#endif
```